### PR TITLE
fix(treasury): fix distribute condition

### DIFF
--- a/contracts/MangoTreasury.sol
+++ b/contracts/MangoTreasury.sol
@@ -57,14 +57,12 @@ contract MangoTreasury is ITreasury, Initializable, Ownable, Pausable, Reentranc
     }
 
     function distribute() public nonReentrant whenNotPaused {
-        uint256 amount = getDistributableAmount();
-        if (amount > 0) {
+        if (block.timestamp > lastDistributedAt) {
+            uint256 amount = getDistributableAmount();
             uint256 distributeAmount = IStakedToken(stakedToken).supplyReward(rewardToken, amount);
-            if (distributeAmount > 0) {
-                uint256 mLastDistributedAt = lastDistributedAt;
-                lastDistributedAt = block.timestamp;
-                emit Distribute(distributeAmount, block.timestamp - mLastDistributedAt);
-            }
+            uint256 mLastDistributedAt = lastDistributedAt;
+            lastDistributedAt = block.timestamp;
+            emit Distribute(distributeAmount, block.timestamp - mLastDistributedAt);
         }
     }
 

--- a/test/foundry/unit/MangoTreasury.t.sol
+++ b/test/foundry/unit/MangoTreasury.t.sol
@@ -144,6 +144,36 @@ contract MangoTreasuryUnitTest is Test {
         );
     }
 
+    function testDistributeInSameBlock() public {
+        uint256 usdcBalance = 10000 * 10 ** 6;
+        usdcToken.transfer(address(mangoUsdcTreasury), usdcBalance);
+        uint256 current = TREASURY_REWARD_STARTS_AT + 10;
+        vm.warp(current);
+
+        uint256 count = MockStakedToken(address(mangoStakedToken)).supplyCount();
+        mangoUsdcTreasury.distribute();
+        assertEq(MockStakedToken(address(mangoStakedToken)).supplyCount(), count + 1, "COUNT_0");
+        mangoUsdcTreasury.distribute();
+        assertEq(MockStakedToken(address(mangoStakedToken)).supplyCount(), count + 1, "COUNT_1");
+    }
+
+    function testDistributeWhenDistributableAmountIsZero() public {
+        uint256 usdcBalance = 10000 * 10 ** 6;
+        usdcToken.transfer(address(mangoUsdcTreasury), usdcBalance);
+        uint256 current = TREASURY_REWARD_STARTS_AT + 10;
+        vm.warp(current);
+
+        uint256 count = MockStakedToken(address(mangoStakedToken)).supplyCount();
+        mangoUsdcTreasury.distribute();
+        assertEq(MockStakedToken(address(mangoStakedToken)).supplyCount(), count + 1, "COUNT_0");
+        MockStakedToken(address(mangoStakedToken)).setReceiveAmount(0);
+        vm.warp(block.timestamp + 100);
+        vm.expectEmit(false, false, false, true);
+        emit Distribute(0, 100);
+        mangoUsdcTreasury.distribute();
+        assertEq(MockStakedToken(address(mangoStakedToken)).supplyCount(), count + 2, "COUNT_1");
+    }
+
     function testDistributeWhenStakedTokenReceivesPartially() public {
         uint256 usdcBalance = 10000 * 10 ** 6;
         usdcToken.transfer(address(mangoUsdcTreasury), usdcBalance);

--- a/test/mocks/MockStakedToken.sol
+++ b/test/mocks/MockStakedToken.sol
@@ -8,7 +8,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 contract MockStakedToken {
     using SafeERC20 for IERC20;
 
-    uint256 receiveAmount = type(uint256).max;
+    uint256 public supplyCount;
+    uint256 public receiveAmount = type(uint256).max;
 
     function setReceiveAmount(uint256 amount) external {
         receiveAmount = amount;
@@ -19,6 +20,7 @@ contract MockStakedToken {
             amount = receiveAmount;
         }
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        supplyCount++;
         return amount;
     }
 }


### PR DESCRIPTION
- Changed the `distribute()` function's running condition.
   - Now, it depends on `block.timestamp` instead of the distributable amount to prevent overpaying interest to past depositors.
- Also, I added two unit tests.
   - Call `distribute()` in the same block.
   - When the distribution amount is zero.