### PR TITLE
fix(staking): delete meaningless calculation code

### DIFF
--- a/contracts/MangoStakedToken.sol
+++ b/contracts/MangoStakedToken.sol
@@ -161,7 +161,7 @@ contract MangoStakedToken is IStakedToken, ERC20, Ownable, Pausable, Initializab
         }
     }
 
-    function supplyReward(address token, uint256 amount) external returns (uint256 supplyAmount) {
+    function supplyReward(address token, uint256 amount) external returns (uint256) {
         GlobalRewardSnapshot memory mGlobalRewardSnapshot = _globalRewardSnapshot[token];
         if (mGlobalRewardSnapshot.treasury != msg.sender) {
             revert Errors.MangoError(Errors.ACCESS);
@@ -174,17 +174,17 @@ contract MangoStakedToken is IStakedToken, ERC20, Ownable, Pausable, Initializab
             return 0;
         }
         uint256 rewardPerTokenIncrement = (amount * _RATE_PRECISION) / totalStakedAmount;
-        supplyAmount = _divideCeil(rewardPerTokenIncrement * totalStakedAmount, _RATE_PRECISION);
-        if (supplyAmount == 0) {
+        if (rewardPerTokenIncrement == 0) {
             return 0;
         }
-        IERC20(token).safeTransferFrom(msg.sender, address(this), supplyAmount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         mGlobalRewardSnapshot.rewardPerToken += rewardPerTokenIncrement;
         mGlobalRewardSnapshot.timestamp = uint64(block.timestamp);
 
-        emit DistributeReward(msg.sender, token, supplyAmount, mGlobalRewardSnapshot.rewardPerToken, totalStakedAmount);
+        emit DistributeReward(msg.sender, token, amount, mGlobalRewardSnapshot.rewardPerToken, totalStakedAmount);
         _globalRewardSnapshot[token] = mGlobalRewardSnapshot;
+        return amount;
     }
 
     function addRewardToken(address newRewardToken, address treasury) external onlyOwner {
@@ -211,9 +211,5 @@ contract MangoStakedToken is IStakedToken, ERC20, Ownable, Pausable, Initializab
             revert Errors.MangoError(Errors.INVALID_ADDRESS);
         }
         IERC20(token).safeTransfer(to, IERC20(token).balanceOf(address(this)));
-    }
-
-    function _divideCeil(uint256 x, uint256 y) private pure returns (uint256) {
-        return (x + y - 1) / y;
     }
 }


### PR DESCRIPTION
This line
```solidity
supplyAmount = _divideCeil(rewardPerTokenIncrement * totalStakedAmount, _RATE_PRECISION);
```
is a meaningless calculation.
Reason:
```
rewardPerTokenIncrement = (amount * _RATE_PRECISION) / totalStakedAmount;
// It means:
amount * _RATE_PRECISION = rewardPerTokenIncrement * totalStakedAmount + k; // k < totalStakedAmount
// So,
_divideCeil(rewardPerTokenIncrement * totalStakedAmount, _RATE_PRECISION)
= (rewardPerTokenIncrement * totalStakedAmount + _RATE_PRECISION - 1) / _RATE_PRECISION
= (amount * _RATE_PRECISION - k + _RATE_PRECISION - 1) / _RATE_PRECISION
// Here, in most cases,
k < totalStakedAmount < _RATE_PRECISION
(amount * _RATE_PRECISION - k + _RATE_PRECISION - 1) / _RATE_PRECISION
= amount
```