### PR TITLE
fix: fix setApproval issue and strengthen tests

### DIFF
--- a/contracts/MangoBondPool.sol
+++ b/contracts/MangoBondPool.sol
@@ -94,6 +94,7 @@ contract MangoBondPool is
     }
 
     function setApprovals() public {
+        IERC20(quoteToken).safeApprove(address(_treasury), 0);
         IERC20(quoteToken).safeApprove(address(_treasury), type(uint256).max);
     }
 

--- a/contracts/MangoHost.sol
+++ b/contracts/MangoHost.sol
@@ -30,6 +30,7 @@ contract MangoHost is ICloberMarketHost, Initializable, Ownable, ReentrancyGuard
     function setApprovals(address token) public {
         address receiver = tokenReceiver[token];
         if (receiver != address(0)) {
+            IERC20(token).safeApprove(receiver, 0);
             IERC20(token).safeApprove(receiver, type(uint256).max);
         }
     }

--- a/contracts/MangoTreasury.sol
+++ b/contracts/MangoTreasury.sol
@@ -37,6 +37,7 @@ contract MangoTreasury is ITreasury, Initializable, Ownable, Pausable, Reentranc
     }
 
     function setApprovals() public {
+        IERC20(rewardToken).safeApprove(stakedToken, 0);
         IERC20(rewardToken).safeApprove(stakedToken, type(uint256).max);
     }
 

--- a/test/foundry/unit/MangoTreasury.t.sol
+++ b/test/foundry/unit/MangoTreasury.t.sol
@@ -25,13 +25,14 @@ contract MangoTreasuryUnitTest is Test {
 
     IStakedToken mangoStakedToken;
     IERC20 usdcToken;
+    address mangoUsdcTreasuryLogic;
     MangoTreasury mangoUsdcTreasury;
 
     function setUp() public {
         vm.warp(INITIAL_BLOCK_TIMESTAMP);
         mangoStakedToken = IStakedToken(address(new MockStakedToken()));
         usdcToken = new MockUSDC(INITIAL_USDC_SUPPLY);
-        address mangoUsdcTreasuryLogic = address(new MangoTreasury(address(mangoStakedToken), address(usdcToken)));
+        mangoUsdcTreasuryLogic = address(new MangoTreasury(address(mangoStakedToken), address(usdcToken)));
         mangoUsdcTreasury = MangoTreasury(
             address(
                 new TransparentUpgradeableProxy(
@@ -48,15 +49,42 @@ contract MangoTreasuryUnitTest is Test {
     }
 
     function testInitialize() public {
-        MangoTreasury newMangoUsdcTreasury = new MangoTreasury(address(mangoStakedToken), address(usdcToken));
+        MangoTreasury newMangoUsdcTreasury = MangoTreasury(
+            address(new TransparentUpgradeableProxy(mangoUsdcTreasuryLogic, PROXY_ADMIN, new bytes(0)))
+        );
 
+        assertEq(newMangoUsdcTreasury.lastDistributedAt(), 0, "BEFORE_LAST_RELEASED_AT");
+        assertEq(newMangoUsdcTreasury.owner(), address(0), "BEFORE_OWNER");
+        assertEq(usdcToken.allowance(address(newMangoUsdcTreasury), address(mangoStakedToken)), 0, "BEFORE_ALLOWANCE");
+        address initializer = address(0x1111);
+        vm.prank(initializer);
         newMangoUsdcTreasury.initialize(TREASURY_REWARD_STARTS_AT);
+        assertEq(newMangoUsdcTreasury.lastDistributedAt(), TREASURY_REWARD_STARTS_AT, "AFTER_LAST_RELEASED_AT");
+        assertEq(newMangoUsdcTreasury.owner(), initializer, "AFTER_OWNER");
+        assertEq(
+            usdcToken.allowance(address(newMangoUsdcTreasury), address(mangoStakedToken)),
+            type(uint256).max,
+            "AFTER_ALLOWANCE"
+        );
     }
 
     function testSetApprovals() public {
         MangoTreasury newMangoUsdcTreasury = new MangoTreasury(address(mangoStakedToken), address(usdcToken));
 
-        newMangoUsdcTreasury.setApprovals();
+        vm.prank(address(mangoUsdcTreasury));
+        usdcToken.approve(address(mangoStakedToken), type(uint256).max / 2);
+
+        assertEq(
+            usdcToken.allowance(address(mangoUsdcTreasury), address(mangoStakedToken)),
+            type(uint256).max / 2,
+            "BEFORE"
+        );
+        mangoUsdcTreasury.setApprovals();
+        assertEq(
+            usdcToken.allowance(address(mangoUsdcTreasury), address(mangoStakedToken)),
+            type(uint256).max,
+            "AFTER"
+        );
     }
 
     function testRewardRate() public {


### PR DESCRIPTION
- `setApprovals` will be failed because of the below line of the `SafeERC20` library:
```solidity
        require(
            (value == 0) || (token.allowance(address(this), spender) == 0),
            "SafeERC20: approve from non-zero to non-zero allowance"
        );
```
- Therefore, we should set allowances to 0 before setting allowances to `type(uint256).max).
- Also, I strengthened the `initialize` tests.